### PR TITLE
Ensure model creation uses configured directory

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -10,3 +10,8 @@ If ports 3000 or 11434 are occupied, stop the conflicting services or adjust the
 
 ## Uninstall Fails
 Ensure the script has permission to remove scheduled tasks and files. Running PowerShell as Administrator may help.
+
+## 500: unable to load model
+This error usually means the model was created in a different directory than the one `ollama serve` uses.
+Remove the `smollm3_stack\\models` folder and run the installer again, or ensure `OLLAMA_MODELS` points to
+`smollm3_stack\\models` when running `ollama create`.

--- a/install-smollm3-openwebui-unattended.py
+++ b/install-smollm3-openwebui-unattended.py
@@ -431,7 +431,8 @@ def ensure_smollm3_model():
     binp = str(OLLAMA_BIN if OLLAMA_BIN.exists() else (shutil.which("ollama") or OLLAMA_BIN))
     logger.info(f"- Importing model into Ollama as '{MODEL_NAME}' ...")
     try:
-        run([binp, "create", MODEL_NAME, "-f", str(modelfile)], check=True)
+        env = {**os.environ, "OLLAMA_MODELS": str(OLLAMA_MODELS_DIR)}
+        run([binp, "create", MODEL_NAME, "-f", str(modelfile)], check=True, env=env)
         logger.info("- Model imported.")
     except subprocess.CalledProcessError as e:
         logger.error(f"! Failed to create model: {e.output}")


### PR DESCRIPTION
## Summary
- pass OLLAMA_MODELS to `ollama create` so models land in the same directory used by `serve`
- document resolution for "500: unable to load model" errors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689cceb996808326a0b54fc16d76a691