### PR TITLE
feat: add dev tooling and wrappers for WSL workspace

### DIFF
--- a/doc/Repo-Support-Plan--WSL.md
+++ b/doc/Repo-Support-Plan--WSL.md
@@ -13,12 +13,17 @@ distribution in the repository directory, installs basic tools (Python and
 Git) if missing, and exposes `start`/`resume` and `suspend` actions.
 
 ## Phase 2: Preconfigured Tooling
-- Ensure that system has pre-installed at least these common languages :
-  - C/C++, Rust, Python Development (compiles, linters, test runners)
+- [x] Ensure that system has pre-installed at least these common languages :
+  - C/C++, Rust, Python Development (compilers, linters, test runners)
   - Corresponding compilers, linters, test runners
 
-- Provide chat command wrappers (`!test`, `!lint`, `!build`).
-- Document default environment and configuration.
+- [x] Provide chat command wrappers (`!test`, `!lint`, `!build`).
+- [x] Document default environment and configuration.
+
+`scripts/wsl_workspace.py` now installs `build-essential`, `clang`, `rustc`
+with `cargo`, and Python tooling (`pip`, `flake8`, `pytest`) so a fresh WSL
+instance is ready to lint, test, or build.  New actions `test`, `lint`, and
+`build` execute the corresponding commands inside the repository directory.
 
 ## Phase 3: Integrated Git Operations
 - Implement chat commands for `git pull`, `git status`, `git commit`, and `git push`.

--- a/scripts/wsl_workspace.py
+++ b/scripts/wsl_workspace.py
@@ -2,9 +2,9 @@
 """Utilities for managing a persistent WSL workspace for smollm3-openwebui.
 
 This script helps keep a WSL distribution active in the repository directory
-and exposes commands to suspend or resume the environment.  It also ensures a
-minimal toolchain (Python and Git) is available for basic editing and script
-execution.
+and exposes commands to suspend or resume the environment.  Phase 2 expands the
+toolchain setup so that common development languages and tooling are
+preinstalled, enabling immediate linting, building and testing.
 """
 
 from __future__ import annotations
@@ -31,30 +31,44 @@ def _to_wsl_path(path: str) -> str:
     return str(p)
 
 
-def _ensure_minimal_env(distro: str) -> None:
-    """Install baseline tools inside the WSL distro if missing."""
+def _ensure_dev_env(distro: str) -> None:
+    """Install developer tooling inside the WSL distro if missing."""
 
+    packages = [
+        "build-essential",
+        "clang",
+        "git",
+        "python3",
+        "python3-pip",
+        "python3-venv",
+        "cargo",
+        "rustc",
+        "flake8",
+        "pytest",
+    ]
+    pkg_str = " ".join(packages)
     setup_cmd = (
-        "command -v python3 >/dev/null 2>&1 || "
-        "(sudo apt-get update && sudo apt-get install -y python3 python3-pip git)"
+        "sudo apt-get update && "
+        f"sudo apt-get install -y {pkg_str}"
     )
     subprocess.run(["wsl", "-d", distro, "bash", "-lc", setup_cmd], check=True)
+
+
+def _run_in_wsl(distro: str, repo: str, cmd: str) -> None:
+    """Execute a command inside the WSL distro rooted at the repo path."""
+
+    wsl_repo = _to_wsl_path(repo)
+    subprocess.run(
+        ["wsl", "-d", distro, "bash", "-lc", f"cd '{wsl_repo}' && {cmd}"],
+        check=True,
+    )
 
 
 def start_workspace(distro: str, repo: str) -> None:
     """Open a shell in the WSL distro rooted at the repo path."""
 
-    wsl_repo = _to_wsl_path(repo)
-    _ensure_minimal_env(distro)
-    cmd = [
-        "wsl",
-        "-d",
-        distro,
-        "bash",
-        "-lc",
-        f"cd '{wsl_repo}' && exec bash",
-    ]
-    subprocess.run(cmd, check=True)
+    _ensure_dev_env(distro)
+    _run_in_wsl(distro, repo, "exec bash")
 
 
 def suspend_workspace(distro: str) -> None:
@@ -63,13 +77,40 @@ def suspend_workspace(distro: str) -> None:
     subprocess.run(["wsl", "--terminate", distro], check=True)
 
 
+def run_tests(distro: str, repo: str) -> None:
+    """Run pytest inside the WSL distro."""
+
+    _ensure_dev_env(distro)
+    _run_in_wsl(distro, repo, "pytest")
+
+
+def run_lint(distro: str, repo: str) -> None:
+    """Run flake8 over the repository inside the WSL distro."""
+
+    _ensure_dev_env(distro)
+    _run_in_wsl(distro, repo, "flake8 .")
+
+
+def run_build(distro: str, repo: str) -> None:
+    """Attempt to build the project using common conventions."""
+
+    _ensure_dev_env(distro)
+    build_cmd = (
+        "if [ -f Cargo.toml ]; then cargo build; "
+        "elif [ -f Makefile ]; then make; "
+        "elif [ -f setup.py ]; then python3 setup.py build; "
+        "else echo 'No build step defined.'; fi"
+    )
+    _run_in_wsl(distro, repo, build_cmd)
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         description="Manage a persistent WSL workspace for smollm3-openwebui",
     )
     parser.add_argument(
         "action",
-        choices=["start", "resume", "suspend"],
+        choices=["start", "resume", "suspend", "test", "lint", "build"],
         help="Action to perform",
     )
     parser.add_argument(
@@ -87,8 +128,14 @@ def main() -> None:
 
     if args.action in {"start", "resume"}:
         start_workspace(args.distro, args.repo)
-    else:
+    elif args.action == "suspend":
         suspend_workspace(args.distro)
+    elif args.action == "test":
+        run_tests(args.distro, args.repo)
+    elif args.action == "lint":
+        run_lint(args.distro, args.repo)
+    elif args.action == "build":
+        run_build(args.distro, args.repo)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- expand WSL workspace script to install common development toolchains
- add `test`, `lint`, and `build` actions for running repo commands inside WSL
- document new preconfigured tooling phase in support plan

## Testing
- `python -m py_compile scripts/wsl_workspace.py`
- `python scripts/wsl_workspace.py --help`


------
https://chatgpt.com/codex/tasks/task_b_68a0e2c1cec483268b1035fc022b442c