### PR TITLE
Handle WSL output encoding

### DIFF
--- a/install-smollm3-openwebui-unattended.py
+++ b/install-smollm3-openwebui-unattended.py
@@ -465,9 +465,9 @@ def ensure_openwebui_wsl(distro: str):
         sys.exit(1)
     # wsl.exe emits UTF-16 output; without decoding, distro names contain nulls
     cp = subprocess.run(
-        ["wsl", "-l", "-q"], capture_output=True, text=True, encoding="utf-16"
+        ["wsl", "-l", "-q"], capture_output=True, text=True, encoding="utf-16-le"
     )
-    dlist = [d.strip() for d in cp.stdout.splitlines()]
+    dlist = [d.strip() for d in (cp.stdout or "").splitlines()]
     if distro not in dlist:
         logger.error(f"WSL distro '{distro}' not found. Available: {dlist}")
         sys.exit(1)


### PR DESCRIPTION
## Summary
- handle UTF-16LE output when listing WSL distributions
- guard against missing stdout when checking available distros

## Testing
- `python -m py_compile install-smollm3-openwebui-unattended.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a0dc97681c8326a808a3e86fc558fa