### PR TITLE
feat: stream WSL test output

### DIFF
--- a/doc/Repo-Support-Plan--WSL.md
+++ b/doc/Repo-Support-Plan--WSL.md
@@ -46,8 +46,11 @@ also exposes `snapshot` and `rollback` actions to capture and restore the
 workspace state, enabling quick resets between experimentation steps.
 
 ## Phase 5: Real-time Testing & Feedback
-- Execute tests asynchronously and stream logs back to chat.
-- Highlight failing lines and stack traces in context.
+- [x] Execute tests asynchronously and stream logs back to chat.
+- [x] Highlight failing lines and stack traces in context.
+
+`scripts/wsl_workspace.py` streams `pytest` output as tests run and
+emphasizes failing lines and stack traces in red for immediate context.
 
 ## Phase 6: Collaborative Features
 - Allow multiple users to attach to same environment.


### PR DESCRIPTION
## Summary
- stream pytest logs from WSL sessions in real time
- highlight failing lines and stack traces during test runs
- mark Phase 5 of the WSL support plan complete

## Testing
- `python -m py_compile scripts/wsl_workspace.py`
- `flake8 scripts/wsl_workspace.py` *(fails: command not found; network blocks install)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a0edbb7f0883269c00e3277eef51a3