### PR TITLE
Add Start Menu shortcuts and uninstall script

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ An unattended installer for Windows 11 that sets up Ollama, the SmolLM3-3B model
 - Installs Open WebUI via Docker (preferred) or a Python virtual environment
 - Ensures FFmpeg is present for audio features
 - Logs every action for troubleshooting
+- Creates Start Menu shortcuts for managing services and opening UIs
 
 ## Prerequisites
 - Windows 11

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -22,8 +22,11 @@ The script will download and configure Ollama, the SmolLM3-3B model, Open WebUI,
 - Open WebUI will be available at `http://localhost:3000`
 - The Ollama API will run at `http://localhost:11434`
 
-## 5. Logs
+## 5. Start Menu shortcuts
+The installer creates a **SmolLM3 - Open WebUI** folder in the Windows Start Menu. It includes shortcuts to start or stop Open WebUI and Ollama, open the web interfaces, view logs, and uninstall the stack.
+
+## 6. Logs
 Detailed logs are written to `%LOCALAPPDATA%\smollm3_stack\logs`. Each run creates a timestamped log file and updates `latest-log.txt` with the most recent path.
 
-## 6. Re-running
+## 7. Re-running
 You can re-run the script at any time. It detects completed steps and skips them, making the process idempotent.


### PR DESCRIPTION
## Summary
- Generate a Start Menu folder with commands to start/stop Open WebUI and Ollama
- Include URL shortcuts, log viewer, and an uninstall script
- Document Start Menu shortcuts in README and usage guide

## Testing
- `python -m py_compile install-smollm3-openwebui-unattended.py`


------
https://chatgpt.com/codex/tasks/task_b_68a0729adab4832695f98a95129159b8