### PR TITLE
Fix Open WebUI installation on Ubuntu 24.04 WSL

### DIFF
--- a/install-smollm3-openwebui-unattended.py
+++ b/install-smollm3-openwebui-unattended.py
@@ -494,7 +494,11 @@ def ensure_openwebui_wsl(distro: str):
         )
 
     # Install Open WebUI for the user
-    wsl("python3 -m pip show open-webui >/dev/null 2>&1 || python3 -m pip install --user open-webui")
+    wsl(
+        "python3 -m pip show open-webui >/dev/null 2>&1 || "
+        "python3 -m pip install --user open-webui || "
+        "python3 -m pip install --user --break-system-packages open-webui"
+    )
 
     # Ensure ffmpeg (root only when missing)
     res = wsl("command -v ffmpeg >/dev/null 2>&1", check=False)


### PR DESCRIPTION
## Summary
- handle PEP 668 externally managed Python environment when installing Open WebUI within WSL

## Testing
- `python -m py_compile install-smollm3-openwebui-unattended.py`


------
https://chatgpt.com/codex/tasks/task_b_68a10d7ba6348326b1f099220e156cb8