### PR TITLE
Handle missing pip in WSL venv

### DIFF
--- a/install-smollm3-openwebui-unattended.py
+++ b/install-smollm3-openwebui-unattended.py
@@ -504,6 +504,8 @@ def ensure_openwebui_wsl(distro: str):
             as_root=True,
         )
         wsl(f"python3 -m venv {venv}")
+    # Some distributions build Python without ensurepip in the venv; bootstrap it if missing.
+    wsl(f"[ -x {venv}/bin/pip ] || {venv}/bin/python -m ensurepip --upgrade", check=False)
     wsl(f"{venv}/bin/pip install --upgrade pip", check=False)
     wsl(
         f"{venv}/bin/pip show open-webui >/dev/null 2>&1 || "


### PR DESCRIPTION
## Summary
- Bootstrap `pip` in the WSL Open WebUI virtual environment when it's missing, ensuring the installer can upgrade and use pip within WSL.

## Testing
- `python -m py_compile install-smollm3-openwebui-unattended.py`
- `python install-smollm3-openwebui-unattended.py --help` *(fails: This script is intended for Windows 11.)*


------
https://chatgpt.com/codex/tasks/task_b_68a16df589588326badbe5e009a5f3e5