### PR TITLE
feat: rename installer and add Tomex start-stop scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# SmolLM3 Open WebUI Stack
+# Tomex
 
 An unattended installer for Windows 11 that sets up Ollama, the SmolLM3-3B model, Open WebUI, and FFmpeg in one step.
 
@@ -10,6 +10,7 @@ An unattended installer for Windows 11 that sets up Ollama, the SmolLM3-3B model
 - Logs every action for troubleshooting
 - Optional WSL backend for Open WebUI via `--wsl <distro>`
 - WSL backend installs Open WebUI inside its own Python virtual environment
+- Provides start/stop scripts accessible from Windows and WSL
 
 ## Prerequisites
 - Windows 11
@@ -20,15 +21,15 @@ An unattended installer for Windows 11 that sets up Ollama, the SmolLM3-3B model
 Run the installer from PowerShell or Command Prompt:
 
 ```powershell
-python install-smollm3-openwebui-unattended.py [--wsl <distro-name>]
+python tomex-installer.py [--wsl <distro-name>]
 ```
 
 Use `--wsl <distro-name>` to run Open WebUI inside the specified WSL distribution when Docker is unavailable.
 
-The script can be re-run safely. It will skip steps that are already complete. Logs are written to `%LOCALAPPDATA%\smollm3_stack\logs`.
+The script can be re-run safely. It will skip steps that are already complete. Logs are written to `%LOCALAPPDATA%\tomex\logs`.
 
 ## Repository structure
-- `install-smollm3-openwebui-unattended.py` – main installer script
+- `tomex-installer.py` – main installer script
 - `docs/` – additional documentation such as usage guides
 
 ## Contributing

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -13,7 +13,7 @@ Open PowerShell and navigate to the directory containing the script:
 
 ```powershell
 cd path\to\script
-python install-smollm3-openwebui-unattended.py [--wsl <distro-name>]
+python tomex-installer.py [--wsl <distro-name>]
 ```
 
 Use `--wsl <distro-name>` to launch Open WebUI inside a specific WSL distribution instead of Docker or a Python virtual environment.
@@ -25,7 +25,7 @@ The script will download and configure Ollama, the SmolLM3-3B model, Open WebUI,
 - The Ollama API will run at `http://localhost:11434`
 
 ## 5. Logs
-Detailed logs are written to `%LOCALAPPDATA%\smollm3_stack\logs`. Each run creates a timestamped log file and updates `latest-log.txt` with the most recent path.
+Detailed logs are written to `%LOCALAPPDATA%\tomex\logs`. Each run creates a timestamped log file and updates `latest-log.txt` with the most recent path.
 
 ## 6. Re-running
 You can re-run the script at any time. It detects completed steps and skips them, making the process idempotent.


### PR DESCRIPTION
## Summary
- rename installer to `tomex-installer.py` and switch base directory to `%LOCALAPPDATA%\tomex`
- add cross-platform start/stop scripts and Start Menu shortcuts
- update docs for Tomex name and usage
- keep default model name `smollm3-local`

## Testing
- `python3 -m py_compile tomex-installer.py`


------
https://chatgpt.com/codex/tasks/task_b_68a17552ba948326a45484590d7c5677