### PR TITLE
Add default-distro support for WSL backend and auto-start Tomex stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 - Initial open-source release of the unattended installer.
-- Added optional WSL backend for Open WebUI using `--wsl <distro>`.
-- WSL backend now installs Open WebUI inside a Python virtual environment.
+- Added optional WSL backend for Open WebUI.
+- WSL backend now accepts an optional `--distro` argument and defaults to the user's primary distribution when omitted.
 - Ollama and Open WebUI now run on the same backend for simpler configuration.
+- After installation the Tomex stack starts automatically.

--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ An unattended installer for Windows 11 that sets up Ollama, the SmolLM3-3B model
 - Installs Ollama and Open WebUI together on the chosen backend (Docker, WSL, or a Python virtual environment)
 - Ensures FFmpeg is present for audio features
 - Logs every action for troubleshooting
-- Optional WSL backend via `--backend wsl --distro <name>` installs the stack inside a specified distribution
+- Optional WSL backend via `--backend wsl` (uses the default distribution) or `--backend wsl --distro <name>` installs the stack inside a specified distribution
 - Provides start/stop scripts accessible from Windows and WSL
+- Starts the Tomex stack automatically after installation
 
 ## Prerequisites
 - Windows 11
@@ -26,11 +27,11 @@ python tomex-installer.py --backend <windows|wsl|docker|pip> [options]
 The `--backend` flag selects which installer backend to run. On Windows it defaults to `windows`. Any remaining arguments are passed through to the
 chosen backend. For example:
 
-- `--backend wsl --distro <name>` installs Open WebUI inside the specified WSL distribution.
+- `--backend wsl [--distro <name>]` installs Open WebUI inside the default WSL distribution or the one specified by `--distro`.
 - `--backend docker` runs Open WebUI in a Docker container.
 - `--backend pip` uses a local Python virtual environment.
 
-The script can be re-run safely. It will skip steps that are already complete. Logs are written to `%LOCALAPPDATA%\tomex\logs`.
+After installation the Tomex stack is started automatically. The script can be re-run safely and will skip steps that are already complete. Logs are written to `%LOCALAPPDATA%\tomex\logs`.
 
 ## Repository structure
 - `tomex-installer.py` – wrapper that selects a backend installer

--- a/doc/Developer-Guide.md
+++ b/doc/Developer-Guide.md
@@ -64,7 +64,7 @@ These can be modified to alter default behaviour such as ports or installation d
 ### Open WebUI
 The installer chooses the runtime environment automatically:
 1. **Docker** – `ensure_openwebui_docker()` pulls and runs the `ghcr.io/open-webui/open-webui:latest` image.  It exposes port `OPENWEBUI_PORT` and links to the local Ollama API.
-2. **WSL** – `ensure_openwebui_wsl(distro)` installs Open WebUI into a virtual environment within the specified distribution and configures a scheduled task to start it.
+2. **WSL** – `ensure_openwebui_wsl(distro=None)` installs Open WebUI into the given distribution (or the default when `distro` is `None`) and configures a scheduled task to start it.
 3. **pip/venv** – `ensure_openwebui_pip()` creates a Windows virtual environment, installs Open WebUI and schedules it to start at logon.
 
 ### FFmpeg

--- a/doc/User-Guide.md
+++ b/doc/User-Guide.md
@@ -31,11 +31,11 @@ For ease of use place the script in a directory without spaces in the path.
    ```
 3. Execute the installer:
    ```powershell
-   python install-smollm3-openwebui-unattended.py [--wsl <distro-name>]
+   python install-smollm3-openwebui-unattended.py [--wsl [<distro-name>]]
    ```
 
 ### Command‑line Options
-- `--wsl <distro-name>` – runs Open WebUI inside an existing WSL distribution.  This is useful when Docker is not available.  Specify a distribution name returned by `wsl -l`.
+- `--wsl [<distro-name>]` – runs Open WebUI inside the default WSL distribution or the one specified.  This is useful when Docker is not available.  Specify a distribution name returned by `wsl -l` when targeting a non-default distro.
 
 ### What Happens During Installation
 1. **Directory preparation** – all files live under `%LOCALAPPDATA%\smollm3_stack`.
@@ -43,9 +43,9 @@ For ease of use place the script in a directory without spaces in the path.
 3. **SmolLM3‑3B model** – the GGUF model and an accompanying Modelfile are stored in `%LOCALAPPDATA%\smollm3_stack\models`.  The model is imported into Ollama as `smollm3-local` with context and GPU parameters tuned for local use.
 4. **Open WebUI** – preference order:
    - Docker container named `open-webui`.
-   - WSL virtual environment (when `--wsl` is supplied).
+   - WSL virtual environment (when `--wsl` is supplied, optionally with a distribution name).
    - Python virtual environment in `%LOCALAPPDATA%\smollm3_stack\openwebui-venv`.
-   Autostart is configured through a scheduled task so the interface is available after each login.
+   Autostart is configured through a scheduled task so the interface is available after each login, and the services are started immediately after installation.
 5. **FFmpeg** – installed inside the Docker container, inside WSL, or on the host depending on how Open WebUI is executed.
 6. **Logging** – every action and the output of invoked commands are written to `%LOCALAPPDATA%\smollm3_stack\logs`.  `latest-log.txt` points to the most recent log file.
 
@@ -77,7 +77,7 @@ Re‑run the installer at any time to pull the latest versions of Ollama, Open W
 ## Troubleshooting
 - **Check the logs**: open `%LOCALAPPDATA%\smollm3_stack\logs\latest-log.txt` to find the full log path for the most recent run.
 - **Ports already in use**: ensure nothing else is bound to ports 3000 (Open WebUI) or 11434 (Ollama).
-- **No Docker installed**: install Docker Desktop or run the installer with `--wsl <distro>` or without Docker to use the Python virtual environment.
+- **No Docker installed**: install Docker Desktop or run the installer with `--wsl [<distro>]` or without Docker to use the Python virtual environment.
 - **Model download interrupted**: simply re-run the installer; the download resumes where it left off.
 
 ## Uninstalling

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -18,11 +18,11 @@ python tomex-installer.py --backend <windows|wsl|docker|pip> [options]
 
 The `--backend` flag selects which backend installer to run. On Windows the default is `windows`. Any remaining arguments are forwarded to that backend. Examples:
 
-- `--backend wsl --distro <name>` launches Open WebUI inside the named WSL distribution.
+- `--backend wsl [--distro <name>]` launches Open WebUI inside the default WSL distribution or the one specified.
 - `--backend docker` runs Open WebUI in a Docker container.
 - `--backend pip` uses a local Python virtual environment.
 
-The script will download and configure Ollama, the SmolLM3-3B model, Open WebUI, and FFmpeg. It may take several minutes depending on network speed.
+The script will download and configure Ollama, the SmolLM3-3B model, Open WebUI, and FFmpeg. When finished the services start automatically. Installation may take several minutes depending on network speed.
 
 ## 4. Access the services
 - Open WebUI will be available at `http://localhost:3000`

--- a/installers/wsl.py
+++ b/installers/wsl.py
@@ -2,8 +2,8 @@
 
 This installer runs entirely inside a WSL distribution. It ensures that
 Ollama, the SmolLM3 model, Open WebUI and FFmpeg are installed within the
-distribution and creates simple start/stop helper scripts in the user's
-home directory.
+distribution, creates simple start/stop helper scripts in the user's home
+directory and starts the stack immediately.
 """
 
 from __future__ import annotations
@@ -63,6 +63,12 @@ def create_scripts() -> None:
     stop.chmod(0o755)
 
 
+def start_stack() -> None:
+    """Start the Tomex stack using the helper script."""
+    start = Path.home() / "start-tomex.sh"
+    _run([str(start)])
+
+
 def install(argv: list[str] | None = None) -> None:
     """Install the Tomex stack inside the current WSL distribution."""
     parser = argparse.ArgumentParser(description="Install Tomex inside WSL")
@@ -73,3 +79,4 @@ def install(argv: list[str] | None = None) -> None:
     ensure_ffmpeg()
     ensure_openwebui()
     create_scripts()
+    start_stack()


### PR DESCRIPTION
## Summary
- support `--backend wsl` without `--distro` to target default WSL distro
- start Tomex services automatically after installation
- update documentation for new `--distro` behaviour

## Testing
- `python -m py_compile tomex-installer.py installers/wsl.py`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a1b760581c8326bc5bdc0421f9aff3