### PR TITLE
fix: avoid preloading installer modules

### DIFF
--- a/installers/__init__.py
+++ b/installers/__init__.py
@@ -1,6 +1,19 @@
-"""Backend-specific installer modules for the Tomex project."""
+"""Backend-specific installer modules for the Tomex project.
 
-# Re-export install functions for convenience
-from . import windows, wsl, docker, pip_installer
+Submodules are imported lazily to avoid side effects when using
+``python -m`` with a specific backend. This prevents modules from being
+pre-loaded during package import, which previously triggered a runtime
+warning.
+"""
+
+from importlib import import_module
+from typing import Any
 
 __all__ = ["windows", "wsl", "docker", "pip_installer"]
+
+
+def __getattr__(name: str) -> Any:
+    """Dynamically import installer submodules on first access."""
+    if name in __all__:
+        return import_module(f".{name}", __name__)
+    raise AttributeError(f"module {__name__} has no attribute {name}")


### PR DESCRIPTION
## Summary
- lazily load installer submodules to prevent pre-import side effects

## Testing
- `python -m installers.wsl`


------
https://chatgpt.com/codex/tasks/task_b_68a1be8475388326bb9e49bab69e835e