### PR TITLE
Make backend installers standalone

### DIFF
--- a/installers/docker.py
+++ b/installers/docker.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """Docker backend installer for Tomex.
 
 This installer provisions both Ollama and Open WebUI in Docker containers
@@ -106,4 +107,8 @@ def install(argv: list[str] | None = None) -> None:
     ensure_ollama_container()
     ensure_openwebui_container()
     create_scripts()
+
+
+if __name__ == "__main__":
+    install()
 

--- a/installers/pip_installer.py
+++ b/installers/pip_installer.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """Python virtual environment backend installer for Tomex.
 
 This installer sets up Ollama and FFmpeg on the host system, creates a
@@ -89,3 +90,7 @@ def install(argv: list[str] | None = None) -> None:
     ensure_ffmpeg()
     ensure_openwebui(venv)
     create_scripts(venv)
+
+
+if __name__ == "__main__":
+    install()

--- a/installers/wsl.py
+++ b/installers/wsl.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """WSL backend installer for Tomex.
 
 This installer runs entirely inside a WSL distribution. It ensures that
@@ -96,3 +97,7 @@ def install(argv: list[str] | None = None) -> None:
     ensure_openwebui()
     create_scripts()
     start_stack()
+
+
+if __name__ == "__main__":
+    install()


### PR DESCRIPTION
## Summary
- make pip, Docker and WSL installers executable modules
- invoke backend installers through subprocess so wrapper connects to the proper environment

## Testing
- `python installers/pip_installer.py --help`
- `python installers/docker.py --help`
- `python installers/wsl.py --help`
- `python tomex-installer.py --backend pip` *(fails: `winget` not found)*
- `python tomex-installer.py --backend docker` *(fails: Docker CLI not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a27b96fa88832698120da965bb6056