### PR TITLE
Improve error reporting across installers

### DIFF
--- a/installers/pip_installer.py
+++ b/installers/pip_installer.py
@@ -13,11 +13,22 @@ import os
 import shutil
 import subprocess
 import sys
+import traceback
 from pathlib import Path
 
 
 def _run(cmd: list[str]) -> None:
-    subprocess.run(cmd, check=True)
+    """Run *cmd* and raise a detailed error on failure."""
+
+    proc = subprocess.run(cmd, text=True, capture_output=True)
+    if proc.stdout:
+        print(proc.stdout, end="")
+    if proc.stderr:
+        print(proc.stderr, end="", file=sys.stderr)
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"Command {' '.join(cmd)} failed with exit code {proc.returncode}"
+        )
 
 
 def ensure_ollama() -> None:
@@ -93,4 +104,9 @@ def install(argv: list[str] | None = None) -> None:
 
 
 if __name__ == "__main__":
-    install()
+    try:
+        install()
+    except Exception as exc:
+        print(f"Installation failed: {exc}", file=sys.stderr)
+        traceback.print_exc()
+        sys.exit(1)

--- a/installers/wsl.py
+++ b/installers/wsl.py
@@ -14,6 +14,7 @@ import shutil
 import subprocess
 import sys
 import time
+import traceback
 import urllib.error
 import urllib.request
 from pathlib import Path
@@ -27,7 +28,15 @@ def _run(cmd: list[str]) -> None:
     """
 
     print("+", " ".join(cmd), flush=True)
-    subprocess.run(cmd, check=True)
+    proc = subprocess.run(cmd, text=True, capture_output=True)
+    if proc.stdout:
+        print(proc.stdout, end="")
+    if proc.stderr:
+        print(proc.stderr, end="", file=sys.stderr)
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"Command {' '.join(cmd)} failed with exit code {proc.returncode}"
+        )
 
 
 def _wait_for_ollama(timeout: int = 60) -> None:
@@ -117,4 +126,9 @@ def install(argv: list[str] | None = None) -> None:
 
 
 if __name__ == "__main__":
-    install()
+    try:
+        install()
+    except Exception as exc:
+        print(f"Installation failed: {exc}", file=sys.stderr)
+        traceback.print_exc()
+        sys.exit(1)


### PR DESCRIPTION
## Summary
- enhance subprocess handling in `tomex-installer` and backend installers
- report stdout/stderr and exit codes for failed commands
- surface installation errors with stack traces for easier troubleshooting

## Testing
- `python -m py_compile tomex-installer.py installers/wsl.py installers/docker.py installers/pip_installer.py`


------
https://chatgpt.com/codex/tasks/task_b_68a2f68af7d48326b652d73be7eff185