### PR TITLE
Use dedicated tomex user for WSL backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ An unattended installer for Windows 11 that sets up Ollama, the SmolLM3-3B model
 - Ensures FFmpeg is present for audio features
 - Logs every action for troubleshooting
 - Optional WSL backend via `--backend wsl` (uses the default distribution) or `--backend wsl --distro <name>` installs the stack inside a specified distribution
-- Provides start/stop scripts accessible from Windows and WSL
+- Installs the WSL stack under an isolated `tomex` user with start/stop scripts accessible from Windows and WSL
 - Starts the Tomex stack automatically after installation
 
 ## Prerequisites

--- a/doc/Detailed-Design.md
+++ b/doc/Detailed-Design.md
@@ -108,13 +108,15 @@ The `install()` function orchestrates installation:
 ## WSL Back‑End (`installers/wsl.py`)
 The WSL installer runs entirely inside a distribution and performs a linear
 sequence of steps:
-1. Install Ollama if missing (`ensure_ollama`).
-2. Wait for the Ollama API and pull the `smollm3:3b` model (`ensure_model`).
-3. Install FFmpeg via `apt` (`ensure_ffmpeg`).
-4. Install Open WebUI using `pip` (`ensure_openwebui`).
-5. Generate `start-tomex.sh` and `stop-tomex.sh` in the home directory
+1. Create a dedicated `tomex` system user with the home directory `/opt/tomex`
+   (`ensure_tomex_user`).
+2. Install Ollama if missing (`ensure_ollama`).
+3. Wait for the Ollama API and pull the `smollm3:3b` model (`ensure_model`).
+4. Install FFmpeg via `apt` (`ensure_ffmpeg`).
+5. Install Open WebUI for the `tomex` user using `pip` (`ensure_openwebui`).
+6. Generate `start-tomex.sh` and `stop-tomex.sh` in `/opt/tomex`
    (`create_scripts`).
-6. Launch the stack (`start_stack`)【F:installers/wsl.py†L1-L116】.
+7. Launch the stack as the `tomex` user (`start_stack`)【F:installers/wsl.py†L1-L116】.
 
 Each command is echoed before execution so that the user sees a blow‑by‑blow log
 of what happened.

--- a/doc/WSL-Installer.md
+++ b/doc/WSL-Installer.md
@@ -4,22 +4,23 @@ The `installers/wsl.py` script sets up the complete Tomex stack inside a Windows
 
 ## High-Level Flow
 1. **Argument parsing** – `install()` prepares a CLI parser (currently without options) and begins the installation sequence.
-2. **Ollama** – `ensure_ollama()` checks for the `ollama` binary and runs the official installation script if it is missing.
-3. **Model download** – `ensure_model()` pulls the SmolLM3 3B model using `ollama pull smollm3:3b`.
-4. **FFmpeg** – `ensure_ffmpeg()` installs FFmpeg from `apt` when it is not already available.
-5. **Open WebUI** – `ensure_openwebui()` installs or upgrades the `open-webui` Python package using `pip`.
-6. **Helper scripts** – `create_scripts()` writes executable `start-tomex.sh` and `stop-tomex.sh` scripts in the user’s home directory to launch and terminate Ollama and Open WebUI.
-7. **Launch stack** – `start_stack()` executes `start-tomex.sh`, starting both services immediately.
+2. **Dedicated user** – `ensure_tomex_user()` creates a system account `tomex` with the home directory `/opt/tomex`.
+3. **Ollama** – `ensure_ollama()` checks for the `ollama` binary and runs the official installation script if it is missing.
+4. **Model download** – `ensure_model()` pulls the SmolLM3 3B model using `ollama pull smollm3:3b`.
+5. **FFmpeg** – `ensure_ffmpeg()` installs FFmpeg from `apt` when it is not already available.
+6. **Open WebUI** – `ensure_openwebui()` installs or upgrades the `open-webui` Python package for the `tomex` user.
+7. **Helper scripts** – `create_scripts()` writes executable `start-tomex.sh` and `stop-tomex.sh` scripts in `/opt/tomex` owned by the `tomex` user to launch and terminate Ollama and Open WebUI.
+8. **Launch stack** – `start_stack()` runs `start-tomex.sh` as the `tomex` user, starting both services immediately.
 
 ## Utility Function
 - `_run(cmd)` prints each command it runs and raises an error if the command fails, ensuring the installer stops on errors.
 
 ## Generated Scripts
-- **~/start-tomex.sh** – runs `ollama serve` and `open-webui --host 0.0.0.0` in the background.
-- **~/stop-tomex.sh** – kills processes for Open WebUI and `ollama serve` using `pkill -f`.
+- **/opt/tomex/start-tomex.sh** – runs `ollama serve` and `open-webui --host 0.0.0.0` in the background.
+- **/opt/tomex/stop-tomex.sh** – kills processes for Open WebUI and `ollama serve` using `pkill -f`.
 
 ## Usage
-Run the installer inside a WSL distribution:
+Run the installer inside a WSL distribution (with sufficient privileges to create system users and install packages):
 
 ```bash
 python installers/wsl.py
@@ -28,6 +29,6 @@ python installers/wsl.py
 After completion, use the helper scripts to control the stack:
 
 ```bash
-~/start-tomex.sh  # start services
-~/stop-tomex.sh   # stop services
+/opt/tomex/start-tomex.sh  # start services
+/opt/tomex/stop-tomex.sh   # stop services
 ```

--- a/installers/wsl.py
+++ b/installers/wsl.py
@@ -63,6 +63,25 @@ def _ollama_running() -> bool:
         return False
 
 
+def ensure_tomex_user() -> None:
+    """Create a dedicated 'tomex' user if it doesn't exist."""
+    print("Ensuring 'tomex' user exists...", flush=True)
+    res = subprocess.run(["id", "tomex"], capture_output=True)
+    if res.returncode != 0:
+        _run(
+            [
+                "useradd",
+                "--system",
+                "--create-home",
+                "--home-dir",
+                "/opt/tomex",
+                "--shell",
+                "/bin/bash",
+                "tomex",
+            ]
+        )
+
+
 def ensure_ollama() -> None:
     """Install Ollama if it is not already available."""
     print("Ensuring Ollama is installed...", flush=True)
@@ -104,8 +123,8 @@ def ensure_ffmpeg() -> None:
     """Ensure FFmpeg is installed via apt."""
     print("Checking for FFmpeg...", flush=True)
     if shutil.which("ffmpeg") is None:
-        _run(["sudo", "apt-get", "update"])
-        _run(["sudo", "apt-get", "install", "-y", "ffmpeg"])
+        _run(["apt-get", "update"])
+        _run(["apt-get", "install", "-y", "ffmpeg"])
     else:
         print("FFmpeg already present", flush=True)
 
@@ -113,20 +132,31 @@ def ensure_ffmpeg() -> None:
 def ensure_openwebui() -> None:
     """Install Open WebUI using pip."""
     print("Installing/upgrading Open WebUI...", flush=True)
-    _run([sys.executable, "-m", "pip", "install", "--upgrade", "open-webui"])
+    _run(
+        [
+            "runuser",
+            "-u",
+            "tomex",
+            "--",
+            "bash",
+            "-lc",
+            "python3 -m pip install --upgrade --user open-webui",
+        ]
+    )
 
 
 def create_scripts() -> None:
-    """Create start/stop scripts in the user's home directory."""
+    """Create start/stop scripts in the tomex user's home directory."""
     print("Creating helper scripts...", flush=True)
-    home = Path.home()
+    home = Path("/opt/tomex")
     start = home / "start-tomex.sh"
     start.write_text(
         "#!/bin/bash\n"
         "ollama serve &\n"
-        "open-webui --host 0.0.0.0 &\n"
+        "$HOME/.local/bin/open-webui --host 0.0.0.0 &\n"
     )
     start.chmod(0o755)
+    _run(["chown", "tomex:tomex", str(start)])
 
     stop = home / "stop-tomex.sh"
     stop.write_text(
@@ -135,13 +165,14 @@ def create_scripts() -> None:
         "pkill -f 'ollama serve'\n"
     )
     stop.chmod(0o755)
+    _run(["chown", "tomex:tomex", str(stop)])
 
 
 def start_stack() -> None:
     """Start the Tomex stack using the helper script."""
     print("Starting Tomex...", flush=True)
-    start = Path.home() / "start-tomex.sh"
-    _run([str(start)])
+    start = Path("/opt/tomex") / "start-tomex.sh"
+    _run(["runuser", "-u", "tomex", "--", str(start)])
 
 
 def install(argv: list[str] | None = None) -> None:
@@ -149,6 +180,7 @@ def install(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(description="Install Tomex inside WSL")
     parser.parse_args(argv)
 
+    ensure_tomex_user()
     ensure_ollama()
     ensure_model()
     ensure_ffmpeg()

--- a/tomex-installer.py
+++ b/tomex-installer.py
@@ -41,12 +41,12 @@ def _create_start_menu_shortcuts_wsl(distro: str | None) -> None:
     stop_script = base / "stop-tomex.cmd"
     start_script.write_text(
         "@echo off\n"
-        f"wsl {distro_opt}-u root sh -lc \"~/start-tomex.sh\"\n",
+        f"wsl {distro_opt}-u tomex sh -lc \"~/start-tomex.sh\"\n",
         encoding="utf-8",
     )
     stop_script.write_text(
         "@echo off\n"
-        f"wsl {distro_opt}-u root sh -lc \"~/stop-tomex.sh\"\n",
+        f"wsl {distro_opt}-u tomex sh -lc \"~/stop-tomex.sh\"\n",
         encoding="utf-8",
     )
 


### PR DESCRIPTION
## Summary
- Run WSL installation under an isolated `tomex` system user
- Start menu shortcuts launch WSL scripts as `tomex`
- Remove `sudo` dependency and use `runuser` for `tomex` operations

## Testing
- `python -m py_compile installers/wsl.py tomex-installer.py`
- `python tomex-installer.py --help`


------
https://chatgpt.com/codex/tasks/task_b_68a30094e60483269ac40c2f1a46dee0