### PR TITLE
Add uninstall option to installer backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ chosen backend. For example:
 - `--backend docker` runs Open WebUI in a Docker container.
 - `--backend pip` uses a local Python virtual environment.
 
+All backends support an `--uninstall` option to remove any previously installed
+components. For example, to remove a Docker-based setup:
+
+```powershell
+python tomex-installer.py --backend docker --uninstall
+```
+
 After installation the Tomex stack is started automatically. The script can be re-run safely and will skip steps that are already complete. Logs are written to `%LOCALAPPDATA%\tomex\logs`.
 
 ## Repository structure

--- a/installers/wsl.py
+++ b/installers/wsl.py
@@ -141,10 +141,33 @@ def start_stack(home: Path) -> None:
     _run(["sudo", "-u", APP_USER, str(start)])
 
 
+def uninstall() -> None:
+    """Remove the Tomex stack from this WSL distribution."""
+    print("Uninstalling Tomex...", flush=True)
+    for cmd in [
+        ["sudo", "pkill", "-f", "open-webui"],
+        ["sudo", "userdel", "-r", APP_USER],
+        ["sudo", "apt-get", "remove", "-y", "ffmpeg"],
+    ]:
+        try:
+            _run(cmd)
+        except Exception:
+            pass
+
+
 def install(argv: list[str] | None = None) -> None:
-    """Install the Tomex stack inside the current WSL distribution."""
+    """Install or uninstall the Tomex stack inside the current WSL distribution."""
     parser = argparse.ArgumentParser(description="Install Tomex inside WSL")
-    parser.parse_args(argv)
+    parser.add_argument(
+        "--uninstall",
+        action="store_true",
+        help="remove the Tomex stack from this distribution",
+    )
+    args = parser.parse_args(argv)
+
+    if args.uninstall:
+        uninstall()
+        return
 
     host_ip = _windows_host_ip()
     ensure_host_ollama(host_ip)


### PR DESCRIPTION
## Summary
- add `--uninstall` flag to Docker, pip, Windows and WSL backends
- clean up containers, virtual environments, tasks and helper scripts during uninstall
- document new uninstall capability in README

## Testing
- `python -m py_compile installers/docker.py installers/pip_installer.py installers/windows.py installers/wsl.py tomex-installer.py`


------
https://chatgpt.com/codex/tasks/task_b_68a30c62378c83268b7e6cdb7b3868f8